### PR TITLE
中間層のスタイルを修正

### DIFF
--- a/assets/css/scss/_style.scss
+++ b/assets/css/scss/_style.scss
@@ -512,7 +512,7 @@ textarea.form-control {
 
 /* single page */
 h2 {
-  margin-top: 80px;
+  margin-top: 40px;
   margin-bottom: 30px;
 }
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,8 +17,12 @@
   {{ "<!-- topics -->" | safeHTML }}
   <section class="section pt-0">
     <div class="container">
-      <div class="row mt-5">
-        {{ .Content }}
+      <div class="row">
+        <div class="col-12">
+          <div class="p-3 p-md-5 bg-white">
+            {{ .Content }}
+          </div>
+        </div>
 
         <div class="col-12 text-center">
           <h2 class="section-title mt-0">記事一覧</h2>


### PR DESCRIPTION
中間層のスタイルを整えました。
H2のmagtin-topを80pxから40pxに変えている部分は、中間ページ以外の部分でも適用されます。
